### PR TITLE
Ignore a few more directories from the collection build

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,8 +21,11 @@ repository: https://github.com/ansible-collections/ansible_hub
 homepage: https://github.com/ansible-collections/ansible_hub
 issues: https://github.com/ansible-collections/ansible_hub/issues
 build_ignore:
+  - .ansible/
   - .gitignore
-  - changelogs/.plugin-cache.yaml
+  - .github/
+  - changelogs/
+  - scripts/
   - tools
   - setup.cfg
   - galaxy.yml.j2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Base on PE collection review - adding a few more build-ignore directories as their presence in the collection tarball causes ansible-lint/sanity test errors and they are not needed for collection functionality.

