### PR TITLE
Fix compatibility error message to 4.11

### DIFF
--- a/changelogs/fragments/fix-error-msg.yml
+++ b/changelogs/fragments/fix-error-msg.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed an issue where an incompatibility message was indicating the incorrect version. 
+...

--- a/plugins/modules/ah_group.py
+++ b/plugins/modules/ah_group.py
@@ -84,9 +84,9 @@ def main():
     module.authenticate()
     vers = module.get_server_version()
 
-    if vers >= "4.10" and module.behind_resource_server:
+    if vers >= "4.11" and module.behind_resource_server:
         module.fail_json(
-            msg=f"Module incompatible with server version 4.10 or later, server version is {vers}"
+            msg=f"Module compatible with server version 4.10 or earlier, server version is {vers}"
         )
 
     # Use Pulp with newer versions

--- a/plugins/modules/ah_user.py
+++ b/plugins/modules/ah_user.py
@@ -185,9 +185,9 @@ def main():
     vers = module.get_server_version()
     user = AHUIUser(module)
 
-    if vers >= "4.10" and module.behind_resource_server:
+    if vers <= "4.10" and module.behind_resource_server:
         module.fail_json(
-            msg=f"Module incompatible with server version 4.10 or later, server version is {vers}"
+            msg=f"Module compatible with server version 4.10 or earlier, server version is {vers}"
         )
 
     # Get the user details from its name.

--- a/plugins/modules/group_roles.py
+++ b/plugins/modules/group_roles.py
@@ -153,9 +153,9 @@ def main():
     group = AHPulpGroups(module)
     vers = module.get_server_version()
 
-    if vers >= "4.10" and module.behind_resource_server:
+    if vers >= "4.11" and module.behind_resource_server:
         module.fail_json(
-            msg=f"Module incompatible with server version 4.10 or later, server version is {vers}"
+            msg=f"Module compatible with server version 4.10 or earlier, server version is {vers}"
         )
 
     for index, role_item in enumerate(group_role_data['role_list']):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Corrected the version and compatibility message for modules incompatible with Automation Hub 4.11.
Issue: AAP-52740
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Reproduced and tested against galaxy_ng dev environment using the following playbook (update `module_defaults` as needed for environment to be tested against).  Should present the incompatibility message for v4.11 Automation Hub and succeed adding and removing the group for v4.10

Collection needs to be built and installed locally from source using `ansible-galaxy` prior to running playbook below to test this PR. 

```paste below
---
- name: Testing Galaxy
  hosts: localhost
  connection: local
  gather_facts: false
  collections:
    - ansible.hub
  module_defaults:
    group/ansible.hub.hub:
      ah_host: ""
      ah_username: ""
      ah_password: ""
      validate_certs: "false"

  tasks:
    - name: Test modules
      block:
        - name: Create group
          ansible.hub.ah_group:
            name: "developers"
            state: present

        - name: Delete group
          ansible.hub.ah_group:
            name: "developers"
            state: absent
```
