### PR TITLE
Fix build_ignore patterns not excluding directories

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -33,5 +33,6 @@ build_ignore:
   - galaxy.yml.j2
   - template_galaxy.yml
   - '*.tar.gz'
+  - importer_result.json
   - test
   - galaxy_ng

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -21,11 +21,13 @@ repository: https://github.com/ansible-collections/ansible_hub
 homepage: https://github.com/ansible-collections/ansible_hub
 issues: https://github.com/ansible-collections/ansible_hub/issues
 build_ignore:
-  - .ansible/
+  - .ansible
   - .gitignore
-  - .github/
-  - changelogs/
-  - scripts/
+  - .github
+  - .vscode
+  - .yamllint.yml
+  - changelogs
+  - scripts
   - tools
   - setup.cfg
   - galaxy.yml.j2


### PR DESCRIPTION
## Summary

- Remove trailing slashes from `build_ignore` entries in `galaxy.yml`
- Add `.vscode` and `.yamllint.yml` to `build_ignore`

`ansible-galaxy collection build` uses `fnmatch` to match file/directory names against `build_ignore` patterns. Entries like `.github/` (with trailing slash) never match because directory names in the file listing don't include a trailing slash. This caused `.github`, `changelogs`, `scripts`, and `.ansible` directories to be included in release tarballs despite being in `build_ignore`.