### PR TITLE
fix(ah_token): send auth headers in check_deprecation requests

### DIFF
--- a/changelogs/fragments/fix-ah-token-auth-deprecation-check.yml
+++ b/changelogs/fragments/fix-ah-token-auth-deprecation-check.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - ah_token - Send authentication headers in check_deprecation() version-check
+    requests so deprecation warnings and version gates work correctly when
+    galaxy_ng strips version fields from unauthenticated API root responses
+    (https://redhat.atlassian.net/browse/AAP-68691).

--- a/plugins/modules/ah_token.py
+++ b/plugins/modules/ah_token.py
@@ -101,8 +101,8 @@ def check_deprecation(module):
     API calls to detect the environment.
     """
     # Build auth headers from module params so the version-check request is
-    # authenticated. Without this, galaxy_ng (PR #558+) strips server_version
-    # from the response and the version gates below are silently skipped.
+    # authenticated. Without this, galaxy_ng strips server_version from
+    # unauthenticated responses and the version gates below are silently skipped.
     headers = {"Content-Type": "application/json", "Accept": "application/json"}
     if module.oauth_token:
         headers["Authorization"] = "Token {0}".format(module.oauth_token)

--- a/plugins/modules/ah_token.py
+++ b/plugins/modules/ah_token.py
@@ -79,6 +79,8 @@ ah_token:
   returned: on successful create
 """
 
+import base64
+
 from json import loads
 
 from ansible.module_utils.compat.version import LooseVersion
@@ -98,6 +100,18 @@ def check_deprecation(module):
     resource server detection or get_server_version(), so we make lightweight
     API calls to detect the environment.
     """
+    # Build auth headers from module params so the version-check request is
+    # authenticated. Without this, galaxy_ng (PR #558+) strips server_version
+    # from the response and the version gates below are silently skipped.
+    headers = {"Content-Type": "application/json", "Accept": "application/json"}
+    if module.oauth_token:
+        headers["Authorization"] = "Token {0}".format(module.oauth_token)
+    elif module.username and module.password:
+        basic_str = base64.b64encode(
+            "{0}:{1}".format(module.username, module.password).encode("ascii")
+        )
+        headers["Authorization"] = "Basic {0}".format(basic_str.decode("ascii"))
+
     # Check if behind a resource server by hitting /api/
     try:
         response = module.session.open(
@@ -105,7 +119,7 @@ def check_deprecation(module):
             module.build_url("/api/").geturl(),
             validate_certs=module.verify_ssl,
             timeout=module.request_timeout,
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            headers=headers,
             follow_redirects=True,
         )
         data = loads(response.read())
@@ -126,7 +140,7 @@ def check_deprecation(module):
             module.url._replace(path="/{0}/".format(galaxy_prefix)).geturl(),
             validate_certs=module.verify_ssl,
             timeout=module.request_timeout,
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            headers=headers,
             follow_redirects=True,
         )
         vers_data = loads(vers_response.read())

--- a/tests/integration/targets/ah_token/tasks/main.yml
+++ b/tests/integration/targets/ah_token/tasks/main.yml
@@ -11,18 +11,40 @@
       ansible.hub.ah_token:
         state: present
       register: r
+      ignore_errors: true
       no_log: true
 
+    # Standalone or Gateway with Hub < 4.10: token creation should succeed.
     - name: Check if the token is created
       assert:
         that:
+          - r is success
           - r.changed
+      when: not (ah_behind_gateway | default(false) | bool)
 
-    - name: Check deprecation warning is emitted when behind gateway
+    # Gateway with Hub 4.10-4.11 (AAP 2.5/2.6): token creation succeeds
+    # but a deprecation warning is emitted.
+    - name: Check deprecation warning is emitted when behind gateway (Hub < 4.12)
       assert:
         that:
+          - r is success
+          - r.changed
           - r.warnings is defined
           - r.warnings | length > 0
           - "'ah_token module is deprecated' in r.warnings[0]"
           - "'ansible.platform' in r.warnings[0]"
-      when: ah_behind_gateway | default(false) | bool
+      when:
+        - ah_behind_gateway | default(false) | bool
+        - r is success
+
+    # Gateway with Hub >= 4.12 (AAP 2.7+): module is blocked entirely with
+    # a clear error message directing users to ansible.platform.
+    - name: Check ah_token is blocked on AAP 2.7+ behind gateway
+      assert:
+        that:
+          - r is failed
+          - "'not supported' in r.msg"
+          - "'ansible.platform' in r.msg"
+      when:
+        - ah_behind_gateway | default(false) | bool
+        - r is failed

--- a/tests/integration/targets/ah_token/tasks/main.yml
+++ b/tests/integration/targets/ah_token/tasks/main.yml
@@ -15,16 +15,16 @@
       no_log: true
 
     # Standalone or Gateway with Hub < 4.10: token creation should succeed.
-    - name: Check if the token is created
+    - name: Check if the token is created (standalone)
       assert:
         that:
           - r is success
           - r.changed
       when: not (ah_behind_gateway | default(false) | bool)
 
-    # Gateway with Hub 4.10-4.11 (AAP 2.5/2.6): token creation succeeds
-    # but a deprecation warning is emitted.
-    - name: Check deprecation warning is emitted when behind gateway (Hub < 4.12)
+    # Gateway with Hub 4.10-4.11: token creation succeeds but a deprecation
+    # warning is emitted.
+    - name: Check deprecation warning is emitted when behind gateway (Hub 4.10-4.11)
       assert:
         that:
           - r is success
@@ -37,9 +37,9 @@
         - ah_behind_gateway | default(false) | bool
         - r is success
 
-    # Gateway with Hub >= 4.12 (AAP 2.7+): module is blocked entirely with
-    # a clear error message directing users to ansible.platform.
-    - name: Check ah_token is blocked on AAP 2.7+ behind gateway
+    # Gateway with Hub >= 4.12: module is blocked entirely with a clear
+    # error message directing users to ansible.platform.
+    - name: Check ah_token is blocked on Hub 4.12+ behind gateway
       assert:
         that:
           - r is failed


### PR DESCRIPTION
## Summary

- Send authentication headers in `check_deprecation()` version-check requests so deprecation warnings and version gates work correctly when galaxy_ng strips version fields from unauthenticated API root responses (galaxy_ng PR #558)
- Update `ah_token` integration test to handle all three Gateway version scenarios (standalone, Hub 4.10-4.11 warning, Hub >= 4.12 block)

## Context

The `check_deprecation()` function in `ah_token.py` made unauthenticated HTTP requests to `/api/` and `/api/galaxy/` to detect the Hub version behind the AAP Gateway. With [galaxy_ng PR #558](https://github.com/ansible-automation-platform/galaxy_ng/pull/558), unauthenticated responses no longer include `server_version`, causing the fallback to `"0"` which silently skips:
- The deprecation warning on Hub 4.10-4.11 (AAP 2.5/2.6)
- The hard block on Hub >= 4.12 (AAP 2.7)

This only affects Gateway mode — standalone mode returns early before the version check.

## Changes

**`plugins/modules/ah_token.py`**: Build `Authorization` headers from the module's existing auth params (`oauth_token` or `username`/`password`) and pass them in both `session.open()` calls. Mirrors the auth pattern in `AHModule.make_request()`. Backward compatible — if no credentials are provided, requests remain unauthenticated.

**`tests/integration/targets/ah_token/tasks/main.yml`**: Updated to handle all deployment scenarios using `ignore_errors` and self-selecting `when` conditions:
- Standalone: assert token creation succeeds
- Gateway + Hub 4.10-4.11: assert success with deprecation warning
- Gateway + Hub >= 4.12: assert failure with "not supported" message

## Test plan

- [x] `ansible-test integration -vvv ah_token` against aap-dev Gateway deployment (Hub 4.12) — version block fires correctly, test passes
- [x] Verified unauthenticated `GET /api/galaxy/` returns no `server_version`, authenticated returns `server_version: "4.12.0dev"`


🤖 Generated with [Claude Code](https://claude.com/claude-code)