### PR TITLE
prepare 1.0.7 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ ansible.hub Release Notes
 
 .. contents:: Topics
 
+v1.0.7
+======
+
+Bugfixes
+--------
+
+- ah_token - Send authentication headers in check_deprecation() version-check requests so deprecation warnings and version gates work correctly when galaxy_ng strips version fields from unauthenticated API root responses (https://redhat.atlassian.net/browse/AAP-68691).
+
 v1.0.6
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -61,3 +61,12 @@ releases:
     fragments:
     - deprecate-ah-token-ah-user.yml
     release_date: '2026-03-19'
+  1.0.7:
+    changes:
+      bugfixes:
+      - ah_token - Send authentication headers in check_deprecation() version-check
+        requests so deprecation warnings and version gates work correctly when galaxy_ng
+        strips version fields from unauthenticated API root responses (https://redhat.atlassian.net/browse/AAP-68691).
+    fragments:
+    - fix-ah-token-auth-deprecation-check.yml
+    release_date: '2026-06-18'

--- a/changelogs/fragments/fix-ah-token-auth-deprecation-check.yml
+++ b/changelogs/fragments/fix-ah-token-auth-deprecation-check.yml
@@ -1,5 +1,0 @@
-bugfixes:
-  - ah_token - Send authentication headers in check_deprecation() version-check
-    requests so deprecation warnings and version gates work correctly when
-    galaxy_ng strips version fields from unauthenticated API root responses
-    (https://redhat.atlassian.net/browse/AAP-68691).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: ansible
 name: hub
-version: 1.0.6
+version: 1.0.7
 readme: README.md
 authors:
   - Sean Sullivan (github.com/sean-m-sullivan)


### PR DESCRIPTION
## Summary

- Prepare ansible.hub collection version 1.0.7 for release
- Updated galaxy.yml, changelog, and documentation

## Changes

- **Version bump**: 1.0.6 → 1.0.7
- **Changelog**: ah_token bugfix - send authentication headers in check_deprecation() version-check requests (AAP-68691)

## Checklist

- [x] galaxy-importer v0.4.31 passed locally (matches CRC)
- [x] Changelog entries are accurate
- [x] Version number is correct in galaxy.yml
- [x] Tarball contents verified (no extraneous files)