### PR TITLE
prepare 1.1.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ ansible.hub Release Notes
 
 .. contents:: Topics
 
+v1.1.0
+======
+
+Minor Changes
+-------------
+
+- The minimum supported ansible-core version is now 2.16. ansible-core 2.15 is no longer supported (https://forum.ansible.com/t/red-hat-ansible-automation-platform-is-ending-support-for-ansible-core-2-15-and-python-3-11/45574).
+
 v1.0.7
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -70,3 +70,11 @@ releases:
     fragments:
     - fix-ah-token-auth-deprecation-check.yml
     release_date: '2026-06-18'
+  1.1.0:
+    changes:
+      minor_changes:
+      - The minimum supported ansible-core version is now 2.16. ansible-core 2.15
+        is no longer supported (https://forum.ansible.com/t/red-hat-ansible-automation-platform-is-ending-support-for-ansible-core-2-15-and-python-3-11/45574).
+    fragments:
+    - bump-ansible-core-2.16.yml
+    release_date: '2026-06-26'

--- a/changelogs/fragments/bump-ansible-core-2.16.yml
+++ b/changelogs/fragments/bump-ansible-core-2.16.yml
@@ -1,5 +1,0 @@
----
-minor_changes:
-  - The minimum supported ansible-core version is now 2.16.
-    ansible-core 2.15 is no longer supported
-    (https://forum.ansible.com/t/red-hat-ansible-automation-platform-is-ending-support-for-ansible-core-2-15-and-python-3-11/45574).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: ansible
 name: hub
-version: 1.0.7
+version: 1.1.0
 readme: README.md
 authors:
   - Sean Sullivan (github.com/sean-m-sullivan)


### PR DESCRIPTION
## Summary

- Prepare ansible.hub collection version 1.1.0 for release
- Updated galaxy.yml, changelog, and documentation

## Changes

- **Version bump**: 1.0.7 → 1.1.0
- **Changelog**: Minimum ansible-core bumped to 2.16; ansible-core 2.15 no longer supported ([PR #62](https://github.com/ansible-collections/ansible_hub/pull/62))

## Checklist

- [x] galaxy-importer v0.4.31 passed locally (matches CRC)
- [x] Changelog entries are accurate
- [x] Version number is correct in galaxy.yml
- [x] Tarball contents verified (no extraneous files)